### PR TITLE
修改引入的rust函数

### DIFF
--- a/03-vga-text-mode.md
+++ b/03-vga-text-mode.md
@@ -306,7 +306,7 @@ impl Writer {
 ```rust
 // in src/vga_buffer.rs
 
-use core::fmt;
+use core::fmt::Write;
 
 impl fmt::Write for Writer {
     fn write_str(&mut self, s: &str) -> fmt::Result {


### PR DESCRIPTION
由于编译器存在bug，不这样引用，将会有requires `owned_box` lang_item 报错信息